### PR TITLE
Separate module setup from test assertions in the release contract tests

### DIFF
--- a/scripts/tests/test_release_contract.py
+++ b/scripts/tests/test_release_contract.py
@@ -8,14 +8,17 @@ import pytest
 
 SCRIPT = Path(__file__).parents[1] / "release_contract.py"
 SPEC = importlib.util.spec_from_file_location("release_contract", SCRIPT)
-assert SPEC is not None and SPEC.loader is not None
+# Module setup rather than a test assertion: `assert` here would vanish under
+# `python -O` and surface as an unrelated failure further down.
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load the release contract module from {SCRIPT}")
 release_contract = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(release_contract)
 
 
 def test_repository_release_manifests_are_aligned() -> None:
     root = Path(__file__).parents[2]
-    assert release_contract.validate_manifests(root, "v0.5.7") == "0.5.7"
+    assert release_contract.validate_manifests(root, "v0.5.7") == "0.5.7"  # skipcq: BAN-B101
 
 
 def test_mismatched_tag_is_rejected() -> None:
@@ -58,15 +61,16 @@ def test_source_archive_roundtrip_preserves_required_paths(tmp_path: Path) -> No
 
     with zipfile.ZipFile(archive_path) as archive:
         names = archive.namelist()
-    assert "src/lib.rs" in names
-    assert "bindings/python/src/lib.rs" in names
-    assert "python/calybris/__init__.py" in names
-    assert ".github/workflows/release.yml" in names
-    assert "proptest-regressions/budget.txt" in names
+    assert "src/lib.rs" in names  # skipcq: BAN-B101
+    assert "bindings/python/src/lib.rs" in names  # skipcq: BAN-B101
+    assert "python/calybris/__init__.py" in names  # skipcq: BAN-B101
+    assert ".github/workflows/release.yml" in names  # skipcq: BAN-B101
+    assert "proptest-regressions/budget.txt" in names  # skipcq: BAN-B101
+    # skipcq: BAN-B101
     assert not any(name.startswith(release_contract.SOURCE_INTERNAL_PREFIXES) for name in names)
     denied = (".pyd", ".pdb", ".dll", ".so", ".dylib", ".whl")
-    assert not any(name.endswith(denied) for name in names)
-    assert len(names) == len(set(names))
+    assert not any(name.endswith(denied) for name in names)  # skipcq: BAN-B101
+    assert len(names) == len(set(names))  # skipcq: BAN-B101
 
 
 def test_provenance_rejects_untracked_files(
@@ -84,4 +88,5 @@ def test_provenance_rejects_untracked_files(
     monkeypatch.setattr(release_contract, "_command", fake_command)
     with pytest.raises(SystemExit, match="source tree is dirty"):
         release_contract.write_provenance(tmp_path, tmp_path / "provenance.json", "0.5.7", None)
+    # skipcq: BAN-B101
     assert ("git", "status", "--porcelain=v1", "--untracked-files=all") in commands


### PR DESCRIPTION
The module-level `assert` guarding the loaded spec is setup, not a test assertion: under `python -O` it disappears and the failure resurfaces later as an unrelated `NoneType` error. It now raises instead.

The remaining assertions are marked `skipcq: BAN-B101`. They are pytest assertions and correct as written, but `test_patterns` in `.deepsource.toml` never reaches this directory, so the analyzer reads them as production code.

Note that this does not turn the Python analysis green on its own: the `Documentation Coverage` metric (46.6%) fails independently and is a dashboard-side threshold.