### PR TITLE
Run cargo-semver-checks on a toolchain it supports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,18 @@ jobs:
         with:
           tool: cargo-semver-checks@0.49.0
 
+      # cargo-semver-checks builds rustdoc JSON and refuses any rustc older than
+      # 1.91. It inspects the public API rather than compiling what ships, so it runs
+      # on its own toolchain; the default stays at the MSRV that every build,
+      # test, and lint gate below is meant to prove.
+      - name: Install a current toolchain for cargo-semver-checks
+        run: rustup toolchain install stable --profile minimal
+
       - name: Security and patch-SemVer gates on release commit
         run: |
           cargo audit
           cargo deny check
-          cargo semver-checks check-release --baseline-version 0.5.5
+          cargo +stable semver-checks check-release --baseline-version 0.5.5
           semgrep scan --config p/rust --config p/python --config p/secrets --config p/security-audit --metrics off --error --exclude target .
           bandit -r python/calybris python/calybris_commerce -q
           pip-audit . --strict --progress-spinner off


### PR DESCRIPTION
`cargo-semver-checks` 0.49 builds rustdoc JSON and refuses any rustc older than 1.91. The release preflight pins the toolchain to the 1.85 MSRV, so this gate has never passed and no release has reached PyPI since it was added — the `v0.5.7` tag failed here with:

```
error: rustc version is not high enough: >=1.91.0 needed, got 1.85.0
```

The tool inspects the public API rather than compiling what ships, so it now installs and runs on its own stable toolchain. The default stays at the MSRV that the build, test, and lint gates around it exist to prove.

Everything else in that run passed, including the annotated tag signature check and `advisories ok, bans ok, licenses ok, sources ok`.